### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/vizsemitecs/4f4df84b-4e27-469b-9fac-e0e9fec3159c/836dc79d-8f46-4549-a8dd-0cb6d685c91c/_apis/work/boardbadge/704e3db8-ce79-4157-8d63-4fa341246064)](https://dev.azure.com/vizsemitecs/4f4df84b-4e27-469b-9fac-e0e9fec3159c/_boards/board/t/836dc79d-8f46-4549-a8dd-0cb6d685c91c/Microsoft.RequirementCategory)
 # haajat
 Pos


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vizsemitecs/4f4df84b-4e27-469b-9fac-e0e9fec3159c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.